### PR TITLE
Update broken or paywalled links in generative AI readings lesson

### DIFF
--- a/generative-ai-overview/generative-ai-overview.md
+++ b/generative-ai-overview/generative-ai-overview.md
@@ -2,7 +2,8 @@
 
 The goal of the Generative AI pre-readings is to start Adies off with a common base of information around Large Language Models (LLMs) and the Generative AIs they power, as well as to prepare you for an in-class activity where we will discuss our takeaways and understanding of these readings.
 
-We will be introducing topics around Generative AI and showcasing some tools and techniques for working with them throughout the coursework, so we want to create a shared understanding of generally what an LLM is and how it operates. We acknowledge that students may have different levels of experience and interest with these topics before starting at Ada. Some folks may find it helpful to skim through the materials while others may want to do a couple close readings. 
+We will be introducing topics around Generative AI and showcasing some tools and techniques for working with them throughout the coursework, so we want to create a shared understanding of generally what an LLM is and how it operates. 
+- We acknowledge that students may have different levels of experience and interest with these topics before starting at Ada. Some folks may find it helpful to skim through the materials while others may want to do a couple close readings. 
 
 ## Questions for Reflection
 
@@ -25,8 +26,8 @@ What are some areas of strength and weakness of LLMs?
 * [5 Practical Business Use Cases for Large Language Models](https://opendatascience.com/5-practical-business-use-cases-for-large-language-models/) -  From opendatascience.com
 
 How does bias impact LLMs?
-* *Content Warning: there are no graphic depictions, but there are examples discussed of harmful sexist and racist content created by generative AIs.* [Exploration of bias in ChatGPT and other AI models](https://www.insider.com/chatgpt-is-like-many-other-ai-models-rife-with-bias-2023-1) - from Insider.com
-* [Depression in Black people goes unnoticed by AI models analyzing language in social media posts](https://www.pennmedicine.org/news/news-releases/2024/march/depression-in-black-people-unnoticed-by-ai-analyzing-social-media) - from Penn Medicine News
+* *Content Warning: there are no graphic depictions, but there are examples discussed of harmful racist content created by generative AIs.* [Covert Racism in AI: How Language Models Are Reinforcing Outdated Stereotypes](https://hai.stanford.edu/news/covert-racism-ai-how-language-models-are-reinforcing-outdated-stereotypes) - from Stanford University
+* [Depression in Black people goes unnoticed by AI models analyzing language in social media posts](https://www.pennmedicine.org/news/depression-in-black-people-unnoticed-by-ai-analyzing-social-media) - from Penn Medicine News
 
 How does the physical infrastructure of LLMs impact people and the environment?
 * [Artificial intelligence technology behind ChatGPT was built in Iowa — with a lot of water](https://apnews.com/article/chatgpt-gpt4-iowa-ai-water-consumption-microsoft-f551fde98083d17a7e8d904f8be822c4) - from The Associated Press
@@ -36,7 +37,8 @@ How does the physical infrastructure of LLMs impact people and the environment?
 ## Further Readings
 The following resources are not required reading, but are provided for those who'd like to dive a little deeper into some of the topics above.
 
+* [A Decision Tree to Guide Student AI Use](https://www.edutopia.org/article/student-use-ai-helpful-framework) - From edutopia.org
 * [Recognizing the kinds of biases in Generative AIs](https://www.forbes.com/sites/forbestechcouncil/2023/09/06/navigating-the-biases-in-llm-generative-ai-a-guide-to-responsible-implementation) - From Forbes.com
 * [Chatbot Hallucinations Are Poisoning Web Search](https://www.wired.com/story/fast-forward-chatbot-hallucinations-are-poisoning-web-search/) - From Wired.com
-* [What Happens When a Prompt Doesn't Work?](https://learnprompting.org/docs/basics/prompt_engineering#what-happens-when-a-prompt-doesnt-work) - From learnprompting.org
 * [Exclusive: OpenAI Used Kenyan Workers on Less Than $2 Per Hour to Make ChatGPT Less Toxic](https://time.com/6247678/openai-chatgpt-kenya-workers/) - From Time USA
+* *Content Warning: there are no graphic depictions, but there are examples discussed of harmful sexist and racist content created by generative AIs.* [Exploration of bias in ChatGPT and other AI models](https://web.archive.org/web/20250525015159/https://www.businessinsider.com/chatgpt-is-like-many-other-ai-models-rife-with-bias-2023-1) - Web archive of an article from Insider.com

--- a/generative-ai-overview/generative-ai-overview.md
+++ b/generative-ai-overview/generative-ai-overview.md
@@ -3,7 +3,14 @@
 The goal of the Generative AI pre-readings is to start Adies off with a common base of information around Large Language Models (LLMs) and the Generative AIs they power, as well as to prepare you for an in-class activity where we will discuss our takeaways and understanding of these readings.
 
 We will be introducing topics around Generative AI and showcasing some tools and techniques for working with them throughout the coursework, so we want to create a shared understanding of generally what an LLM is and how it operates. 
-- We acknowledge that students may have different levels of experience and interest with these topics before starting at Ada. Some folks may find it helpful to skim through the materials while others may want to do a couple close readings. 
+
+### !callout-info
+
+## Engage According to Your Experience Level
+
+We acknowledge that students may have different levels of experience and interest with these topics before starting at Ada. Some folks may find it helpful to skim through the materials while others may want to do a couple close readings. 
+
+### !end-callout
 
 ## Questions for Reflection
 
@@ -26,7 +33,8 @@ What are some areas of strength and weakness of LLMs?
 * [5 Practical Business Use Cases for Large Language Models](https://opendatascience.com/5-practical-business-use-cases-for-large-language-models/) -  From opendatascience.com
 
 How does bias impact LLMs?
-* *Content Warning: there are no graphic depictions, but there are examples discussed of harmful racist content created by generative AIs.* [Covert Racism in AI: How Language Models Are Reinforcing Outdated Stereotypes](https://hai.stanford.edu/news/covert-racism-ai-how-language-models-are-reinforcing-outdated-stereotypes) - from Stanford University
+* *Content Warning: there are no graphic depictions, but there are examples of harmful racist content created by generative AIs.*
+  * [Covert Racism in AI: How Language Models Are Reinforcing Outdated Stereotypes](https://hai.stanford.edu/news/covert-racism-ai-how-language-models-are-reinforcing-outdated-stereotypes) - from Stanford University
 * [Depression in Black people goes unnoticed by AI models analyzing language in social media posts](https://www.pennmedicine.org/news/depression-in-black-people-unnoticed-by-ai-analyzing-social-media) - from Penn Medicine News
 
 How does the physical infrastructure of LLMs impact people and the environment?
@@ -41,4 +49,5 @@ The following resources are not required reading, but are provided for those who
 * [Recognizing the kinds of biases in Generative AIs](https://www.forbes.com/sites/forbestechcouncil/2023/09/06/navigating-the-biases-in-llm-generative-ai-a-guide-to-responsible-implementation) - From Forbes.com
 * [Chatbot Hallucinations Are Poisoning Web Search](https://www.wired.com/story/fast-forward-chatbot-hallucinations-are-poisoning-web-search/) - From Wired.com
 * [Exclusive: OpenAI Used Kenyan Workers on Less Than $2 Per Hour to Make ChatGPT Less Toxic](https://time.com/6247678/openai-chatgpt-kenya-workers/) - From Time USA
-* *Content Warning: there are no graphic depictions, but there are examples discussed of harmful sexist and racist content created by generative AIs.* [Exploration of bias in ChatGPT and other AI models](https://web.archive.org/web/20250525015159/https://www.businessinsider.com/chatgpt-is-like-many-other-ai-models-rife-with-bias-2023-1) - Web archive of an article from Insider.com
+* *Content Warning: there are no graphic depictions, but there are examples of harmful sexist and racist content created by generative AIs.*
+  * [Exploration of bias in ChatGPT and other AI models](https://web.archive.org/web/20250525015159/https://www.businessinsider.com/chatgpt-is-like-many-other-ai-models-rife-with-bias-2023-1) - Web archive of an article from Insider.com


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/1/181459410160484/project/1205655776549324/task/1207497586945996?focus=true) - Ticket was for creating instructor resource, but wanted to get broken links fixed with this ticket before precourse.

# Changes
- Breaks up one of the intro paragraphs for readability
## Under "How does bias impact LLMs?"
- Replace broken Penn news release link with "permanent" link to the article
- Replace Business insider link behind paywall with Stanford article that covers similar topics
## Under Optional Readings
- Replace the removed article under optional readings "What Happens When a Prompt Doesn't Work?" with "A Decision Tree to Guide Student AI Use" from Edutopia
- Add link to a web archive of the business insider article to the bottom of optional readings
